### PR TITLE
CMC rank

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 # beatrice
 settings.py
 *.db
+/.vs

--- a/api.py
+++ b/api.py
@@ -89,5 +89,19 @@ async def get_all_prices():
     ret.sort(key=lambda tup: tup[1], reverse=True)
     return ret
 
-
+async def get_cmc_rank(cap):
+	try:
+		open('cmc.txt', 'r')
+	except IOError:
+		return "0"
+	
+	f = open('cmc.txt', 'r')
+	r = eval(f.read())
+	f.close()
+	i = 1
+	for coin in r['data']:
+		if coin['quote']['USD']['market_cap'] < cap:
+			return i
+		else:
+			i += 1
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import discord
 from discord.ext import commands
 from discord.ext.commands import Bot
+from coinmarketcap_pro.client import Client
 import asyncio
 import datetime
 import re

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 peewee
 git+https://github.com/Rapptz/discord.py@rewrite#egg-discord.py[voice]
+git+https://github.com/sterlingbeason/coinmarketcap-professional


### PR DESCRIPTION
i don't collaborate much on python so my tabs may be effed

and untested. heh.

i'd like the query from CMC to happen immediately, then have it wait 7200 seconds until another query. so i hope that works right. reason for 7200 seconds is so you stay under 6000 queries a month, according to the free API specs. https://pro.coinmarketcap.com

also i didn't test requirements but you'll need that API wrapper