### PR TITLE
banpernan = nano['usdprice'] / banano['usdprice']

### DIFF
--- a/main.py
+++ b/main.py
@@ -359,6 +359,7 @@ async def price(ctx):
     if nano is None:
         embed.description += '\nCurrently Unavailable\n'
     else:
+        banpernan = nano['usdprice'] / banano['usdprice']
         embed.description += "```"
         embed.description += f"Rank            : #{nano['rank']}\n"
         embed.description += f"Price  (Kucoin) : {nano['kucoin']:.8f} BTC\n"


### PR DESCRIPTION
After a suggestion from Sir Ark on Discord, if NANO price is not equal to none, banpernan will be updated to equal nano['usdprice'] / banano['usdprice']