### PR TITLE
New farms command

### DIFF
--- a/settings.py.example
+++ b/settings.py.example
@@ -32,3 +32,6 @@ VESPRICE=False
 KICK_LOG=633355534535491605
 # Jail channel id (For sending messages to recently jailed people, who may not be able to see the channel they were just jailed in)
 JAIL_ID=416306504124071938
+
+#zapper api key for wban farms. Base64 encoding of public one on https://studio.zapper.fi/docs/apis/endpoints-api-keys
+ZAPPER_API="OTZlMGNjNTEtYTYyZS00MmNhLWFjZWUtOTEwZWE3ZDJhMjQxOg=="


### PR DESCRIPTION
Added a command that uses the zapper API to get current TVL and APR of all running wrapped banano Farms. 

To be run, requires a new variable in the settings.py (ZAPPER_API) which is the base64 encoding of a zapper API key. The public one (used in the example settings) should work well enough, but requesting a custom one if we ever encounter problems with that one would also be a valid option (see https://studio.zapper.fi/docs/apis/endpoints-api-keys for more details on that)