### PR TITLE
Updated Zapper API key

### DIFF
--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -38,5 +38,5 @@ data:
     KICK_LOG=633355505556783104
     # Jail channel id (For sending messages to recently jailed people, who may not be able to see the channel they were just jailed in)
     JAIL_ID=416306504124071938
-    #zapper api key for wban farms. Base64 encoding of public one on https://studio.zapper.fi/docs/apis/endpoints-api-keys
-    ZAPPER_API="OTZlMGNjNTEtYTYyZS00MmNhLWFjZWUtOTEwZWE3ZDJhMjQx=="
+    #zapper api key for wban farms. https://studio.zapper.fi/docs/apis/endpoints-api-keys
+    ZAPPER_API = os.getenv('ZAPPER_API_KEY') 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -32,6 +32,11 @@ spec:
               secretKeyRef:
                 name: beatrice
                 key: bot_token
+          - name: ZAPPER_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: beatrice
+                key: zapper_api_key
         volumeMounts:
         - name: conf
           mountPath: /config

--- a/settings.py.example
+++ b/settings.py.example
@@ -33,5 +33,5 @@ KICK_LOG=633355534535491605
 # Jail channel id (For sending messages to recently jailed people, who may not be able to see the channel they were just jailed in)
 JAIL_ID=416306504124071938
 
-#zapper api key for wban farms. Base64 encoding of public one on https://studio.zapper.fi/docs/apis/endpoints-api-keys
-ZAPPER_API="OTZlMGNjNTEtYTYyZS00MmNhLWFjZWUtOTEwZWE3ZDJhMjQx=="
+#zapper api key for wban farms. There currently is no public one anymore, so you'll have to request one 
+ZAPPER_API=""


### PR DESCRIPTION
Zapper removed the public API key, this change now updates it to instead use a private API key.

Updated kubernetes to load this from the secretKeyRef. 