### PR TITLE
 Fix farms command

### DIFF
--- a/main.py
+++ b/main.py
@@ -733,7 +733,7 @@ async def farms(ctx):
 
     last_farms[message.channel.id] = datetime.datetime.now()
     #Get the API response
-    apiResponse = await api.getWBANFARM()
+    apiResponse = await api.getWbanFarms()
     #In case something went wrong 
     if apiResponse == None or apiResponse == []:
         await ctx.send("API Error")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ discord.py>=1.3.4
 aioredis==1.3.1
 requests
 redis
+web3>=6.20.0


### PR DESCRIPTION
Fixes farms command, which broke due to changes to Zapper API.

With this, computation of APR is now performed using the on-chain contract data. Plan is to later expand the use of these to remove usage of the Zapper API.