### PR TITLE
Fix !price NANO display and crash on unavailable data

### DIFF
--- a/api.py
+++ b/api.py
@@ -58,7 +58,6 @@ async def get_banano_price():
         response = json.loads(response)
     if response is not None and 'market_data' in response:
         # Get price and volume
-        banpernan = float(response['market_data']['market_cap']['btc']) / float(await redis.get("nano-btc-price"))
         usdprice = float(response['market_data']['current_price']['usd'])
         satprice = float(response['market_data']['current_price']['btc']) * 100000000
         volumebtc = float(response["market_data"]["total_volume"]["btc"])
@@ -67,7 +66,6 @@ async def get_banano_price():
         rank = response['market_cap_rank']
         mcap = float(response['market_data']['market_cap']['usd'])
         ret = {
-            "xrb":banpernan,
             "satoshi":satprice,
             "volume":volumebtc,
             "supply":circ_supply,
@@ -96,25 +94,16 @@ async def get_nano_price():
     else:
         response = json.loads(response)
     if response is not None and 'market_data' in response:
-        # Cache nano-btc price
-        await redis.set("nano-btc-price", f"{response['market_data']['market_cap']['btc']:.16f}")
         # Get price and volume
-        volumebtc = float(response["market_data"]["total_volume"]["btc"])
-        kucoinprice = 0
-        binanceprice = 0
-        for t in response['tickers']:
-            if t['market']['identifier'] == 'kucoin' and t['target'] == 'BTC':
-                kucoinprice = float(t['last'])
-            elif t['market']['identifier'] == 'binance' and t['target'] == 'BTC':
-                binanceprice = float(t['last'])
         usdprice = float(response["market_data"]["current_price"]["usd"])
+        btcprice = float(response["market_data"]["current_price"]["btc"])
+        volumebtc = float(response["market_data"]["total_volume"]["btc"])
         # Other data
         circ_supply = float(response['market_data']['circulating_supply'])
         rank = response['market_cap_rank']
         mcap = float(response['market_data']['market_cap']['usd'])
         ret = {
-            "kucoin":kucoinprice,
-            "binance":binanceprice,
+            "btcprice":btcprice,
             "volume":volumebtc,
             "supply":circ_supply,
             "rank": rank,

--- a/main.py
+++ b/main.py
@@ -378,8 +378,10 @@ async def price(ctx):
         embed.description += f"Volume (24H)    : {nano['volume']:,.2f} BTC\n"
         embed.description += f"Market Cap      : ${int(nano['mcap']):,}\n"
         embed.description += "```"
-    if btc is not None:
+    if btc is not None and banpernan != "":
         embed.set_footer(text='1 BTC = ${0:,.2f} | 1 NANO = {1:,.2f} BAN | Market Data Provided by CoinGecko.com'.format(btc['usdprice'], banpernan))
+    elif btc is not None:
+        embed.set_footer(text='1 BTC = ${0:,.2f} | Market Data Provided by CoinGecko.com'.format(btc['usdprice']))
     await msg.edit(content="", embed=embed)
 
 @client.command()

--- a/main.py
+++ b/main.py
@@ -353,10 +353,12 @@ async def price(ctx):
             embed.colour=discord.Colour.red()
         embed.description += "```"
         embed.description += f"Rank            : #{banano['rank']}\n"
-        embed.description += f"Price  (NANO)   : {banano['xrb']:.6f} NANO\n"
+        if nano is not None:
+            ban_in_nano = banano['usdprice'] / nano['usdprice']
+            banpernan = 1 / ban_in_nano
+            embed.description += f"Price  (NANO)   : {ban_in_nano:.6f} NANO\n"
         embed.description += f"Price  (BTC)    : {banano['satoshi']:.1f} sats\n"
         embed.description += f"Price  (USD)    : ${banano['usdprice']:.6f}\n"
-        banpernan = 1/banano['xrb']
         if settings.VESPRICE and 'bolivar' in banano:
             embed.description += f"Price  (VES)    : {banano['bolivar']:.2f} Bs.S\n"
         embed.description += f"Volume (24H)    : {banano['volume']:,.2f} BTC\n"
@@ -369,8 +371,7 @@ async def price(ctx):
         banpernan = nano['usdprice'] / banano['usdprice']
         embed.description += "```"
         embed.description += f"Rank            : #{nano['rank']}\n"
-        embed.description += f"Price  (Kucoin) : {nano['kucoin']:.8f} BTC\n"
-        embed.description += f"Price  (Binance): {nano['binance']:.8f} BTC\n"
+        embed.description += f"Price  (BTC)    : {nano['btcprice']:.8f} BTC\n"
         embed.description += f"Price  (USD)    : ${nano['usdprice']:.2f}\n"
         if settings.VESPRICE and 'bolivar' in nano:
             embed.description += f"Price  (VES)    : {nano['bolivar']:.2f} Bs.S\n"


### PR DESCRIPTION
## Summary
  - Fix "Price (NANO)" showing wrong value (was market cap / price ratio, now actual BAN price in NANO)
  - Replace broken Kucoin/Binance ticker parsing with CoinGecko aggregated BTC price (KuCoin no longer has a NANO/BTC pair)
  - Fix crash when NANO data is unavailable due to CoinGecko rate limiting
